### PR TITLE
Fix ontology topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-*.o
-*.d
 preprocessor
 processor

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-OBJS=gafparser oboparser preprocessor termbuilder linkbuilder
-GOMPOBJS=processor
-
-CFLAGS=-Wall -Wextra -Wshadow -Winline -std=c++11 -lm -g
-FASTFLAGS=-fopenmp
+CFLAGS=-Wall -Wextra -Wshadow -Winline -std=c++11 -lm -O3
+FASTFLAGS=-fopenmp -fwhole-program
 
 SHELL=/bin/bash
 
@@ -10,25 +7,12 @@ SHELL=/bin/bash
 
 all: preprocessor processor
 
-%.d: %.cpp
-	-@echo "  DEP    $@"
-	@g++ -std=c++11 -MM $< > $@
--include $(OBJS:%=%.d) $(GOMPOBJS:%=%.d)
-
-$(OBJS:%=%.o): %.o: %.cpp
-	-@echo "  C++    $@"
-	@g++ $(CFLAGS) -c $< -o $@
-
-$(GOMPOBJS:%=%.o): %.o: %.cpp
-	-@echo "  MPC++  $@"
-	@g++ $(CFLAGS) $(FASTFLAGS) -c $< -o $@
-
-preprocessor: preprocessor.o oboparser.o gafparser.o termbuilder.o linkbuilder.o
-	-@echo "  LD     $@"
+preprocessor: preprocessor.cpp oboparser.cpp gafparser.cpp termbuilder.cpp linkbuilder.cpp
+	-@echo "  PROG   $@"
 	@g++ $(CFLAGS) $^ -o $@
 
-processor: processor.o
-	-@echo "  LD     $@"
+processor: processor.cpp
+	-@echo "  PROG   $@"
 	@g++ $(CFLAGS) $(FASTFLAGS) $^ -o $@
 
 formatter_test: formatters.cpp
@@ -45,6 +29,5 @@ test.out: processor obo.bin gaf.bin input_genes.txt
 	-@time ./processor 0.2 2 obo.bin gaf.bin input_genes.txt > test.out
 
 clean:
-	-rm $(OBJS:%=%.o) $(GOMPOBJS:%=%.o) preprocessor processor formatter_test
+	-rm preprocessor processor formatter_test
 distclean: clean
-	-rm $(OBJS:%=%.d) $(GOMPOBJS:%=%.d)

--- a/preprocessor.cpp
+++ b/preprocessor.cpp
@@ -86,6 +86,10 @@ static int obo_processor(char **out_buf, size_t *buf_len)
 				{
 					term->name=val;
 				}
+				if (!strcmp(key,"namespace"))
+				{
+					term->name_space=val;;
+				}
 				if (!strcmp(key,"is_a"))
 				{
 					term->isa.insert(val);
@@ -115,7 +119,7 @@ static int obo_processor(char **out_buf, size_t *buf_len)
 				}
 				if (!strcmp(key,"is_obsolete") && !strcmp(val,"true"))
 				{
-					//term->obsolete=true; //XXX TODO odkomentiraj
+					term->obsolete=true;
 				}
 			}
 		}

--- a/preprocessor.h
+++ b/preprocessor.h
@@ -39,7 +39,7 @@ struct term_t
 {
 	std::set<struct term_t*> parents,children;
 	std::set<const char*, ltstr> isa,isa_for; /*isa_for is parent->child link cache in order to fill out isa's*/
-	const char *id,*name;
+	const char *id,*name,*name_space;
 	bool obsolete;
 
 	ptrdiff_t i_parents,i_children,i_this,i_render;

--- a/processor.cpp
+++ b/processor.cpp
@@ -336,7 +336,7 @@ static void termtree_dump_children(struct int_term_t *root)
 
 static void termtree_dump_term(struct int_term_t *root)
 {
-	root->dumped=1;
+	root->flags.dumped=1;
 	print_buf(root->prerender.str,root->prerender_len);
 	print_buf(root->genebuf,root->intersect_len);
 	print_buf(",\"children\":[",13);
@@ -492,19 +492,19 @@ int main(int argc, const char *argv[])
 	bool prevroot=false;
 	for (int i=(int)roots.size()-1;i>=0;i--)
 	{
-		if (!strcmp(roots[i]->id.str,"GO:0008150"))
+		if (roots[i]->flags.type == 1 && roots[i]->flags.obsolete == 0)
 		{
 			if (prevroot) { outbuf[outcursor++]=','; }
 			prevroot=true;
 			print_buf("\"BP\":[",6);
 		}
-		else if (!strcmp(roots[i]->id.str,"GO:0005575"))
+		else if (roots[i]->flags.type == 2 && roots[i]->flags.obsolete == 0)
 		{
 			if (prevroot) { outbuf[outcursor++]=','; }
 			prevroot=true;
 			print_buf("\"CC\":[",6);
 		}
-		else if (!strcmp(roots[i]->id.str,"GO:0003674"))
+		else if (roots[i]->flags.type == 3 && roots[i]->flags.obsolete == 0)
 		{
 			if (prevroot) { outbuf[outcursor++]=','; }
 			prevroot=true;
@@ -532,7 +532,7 @@ int main(int argc, const char *argv[])
 	bool first=true;
 	for (int i=0;i<nterms;i++)
 	{
-		if (!terms[i].dumped) { continue; }
+		if (!terms[i].flags.dumped) { continue; }
 		if (!first) { print_char(','); }
 		first=false;
 		print_buf(terms[i].genebuf+terms[i].intersect_len,terms[i].genes_len);

--- a/processor.h
+++ b/processor.h
@@ -128,7 +128,17 @@ struct int_term_t
 	} id,name,prerender;
 	struct quick_set_t genes,intersect;
 	float_type pval,score;
-	int prerender_len,genes_len,intersect_len,dumped;
+	int prerender_len,genes_len,intersect_len;
+	union
+	{
+		struct
+		{
+			unsigned dumped: 1;
+			unsigned type: 2;
+			unsigned obsolete: 1;
+		};
+		int all;
+	} flags;
 	long color;
 	char *genebuf;
 };

--- a/processor.h
+++ b/processor.h
@@ -50,7 +50,9 @@ struct StrEq
 {
 	bool operator()(const char *str1, const char *str2) const
 	{
-		return strcmp(str1,str2)==0;
+		size_t len1=((size_t*)str1)[-2];
+		size_t len2=((size_t*)str2)[-2];
+		return len1==len2 && strcmp(str1,str2)==0;
 	}
 };
 struct PtrEq

--- a/termbuilder.cpp
+++ b/termbuilder.cpp
@@ -35,7 +35,7 @@ static map<const char*, ptrdiff_t, ltstr> stringset;
 void add_term(struct term_t *term)
 {
 	if (term==NULL) { return; }
-	if (term==NULL || term->obsolete==true || tree.count(term->name)>0) { return; }
+	if (term==NULL || tree.count(term->name)>0) { return; }
 	tree[term->id]=term;
 }
 
@@ -163,6 +163,23 @@ int coagulate_terms(char **buf, size_t *buf_len)
 		it->nchildren=t->children.size();
 		it->id.idx=stringset[t->id];
 		it->name.idx=stringset[t->name];
+		it->flags.obsolete=t->obsolete;
+		if (!strcmp(t->name_space,"biological_process"))
+		{
+			it->flags.type=1;
+		}
+		if (!strcmp(t->name_space,"cellular_component"))
+		{
+			it->flags.type=2;
+		}
+		if (!strcmp(t->name_space,"molecular_function"))
+		{
+			it->flags.type=3;
+		}
+		if (it->flags.type!=0 && it->flags.obsolete==0 && t->parents.size()==0)
+		{
+			fprintf(stderr,"root term %s is a %d\n",t->id,(int)it->flags.type);
+		}
 
 		int renderlen;
 		it->prerender.idx=renderbuf-*buf;


### PR DESCRIPTION
Instead of hardcoding root term IDs, properly take into account the obsoletion flag present in the input obo file. The IDs were ontology-dependent and thus prevented using the tool with different ontologies.